### PR TITLE
Make MojoX::MIME::Types consistent with Mojolicious::Types

### DIFF
--- a/lib/MojoX/MIME/Types.pm
+++ b/lib/MojoX/MIME/Types.pm
@@ -3,7 +3,7 @@
 # Copyright Mark Overmeer.  Licensed under the same terms as Perl itself.
 
 package MojoX::MIME::Types;
-use Mojo::Base -base;
+use Mojo::Base 'Mojolicious::Types';
 
 use MIME::Types   ();
 
@@ -99,6 +99,15 @@ sub types(;$)
     my $t = MIME::Types->_MojoExtTable;
     while(my ($ext, $type) = each %$t) { $exttable{$ext} = [$type] }
     $self->{MMT_ext} = \%exttable;
+}
+
+=method mapping [\%table]
+Alias for C<$obj-E<gt>types>
+=cut
+
+sub mapping(;$)
+{
+    goto &types;
 }
 
 #----------

--- a/t/40mojo.t
+++ b/t/40mojo.t
@@ -12,7 +12,7 @@ use Test::More;
 eval "require Mojo::Base";
 plan skip_all => 'Mojo probably not installed' if $@;
 
-plan tests => 14;
+plan tests => 10;
 
 require_ok('MojoX::MIME::Types');
 
@@ -20,13 +20,17 @@ my $m = MojoX::MIME::Types->new;
 isa_ok($m, 'MojoX::MIME::Types');
 isa_ok($m->mimeTypes, 'MIME::Types');
 
-my $t = $m->types;
-isa_ok($t, 'HASH', 'types table (deprecated)');
-cmp_ok(keys %$t, '>', 1000, 'MIME::Types describes '.(keys %$t).' extensions');
-ok(exists $t->{txt});
-isa_ok($t->{txt}, 'ARRAY');
-cmp_ok(@{$t->{txt}}, '==', 1);
-is($t->{txt}[0], 'text/plain');
+for my $method ( 'types', 'mapping' ) {
+    subtest "->$method" => sub {
+        my $t = $m->$method;
+        isa_ok($t, 'HASH', 'types table (deprecated)');
+        cmp_ok(keys %$t, '>', 1000, 'MIME::Types describes '.(keys %$t).' extensions');
+        ok(exists $t->{txt});
+        isa_ok($t->{txt}, 'ARRAY');
+        cmp_ok(@{$t->{txt}}, '==', 1);
+        is($t->{txt}[0], 'text/plain');
+    };
+}
 
 my $ext = $m->detect('text/html, application/json;q=9');
 isa_ok($ext, 'ARRAY', 'detect() reports '.@$ext);


### PR DESCRIPTION
MojoX::MIME::Types makes Mojolicious 8.0 broken

- Mojolicious::Types is base for MojoX::MIME::Types
So, now new methods from Mojolicious::Types are in MojoX::MIME::Types too
- Add method `->mapping` as alias for `->types`